### PR TITLE
OAuth2 (Keycloak) Integration with a Toy Endpoint

### DIFF
--- a/api/openapi3_0.yaml
+++ b/api/openapi3_0.yaml
@@ -38,6 +38,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ID'
+  /scenarios/protected:
+    post:
+      tags:
+        - Simulations
+      summary: Toy endpoint to demonstrate authorization flow
+      description: Toy hello-world like endpoint returns a message if request is authorized, no actual new scenario will be created
+      operationId: createProtectedScenario
+      responses:
+        '200':
+          description: Authorized user created scenario (fake)
+        '401':
+          description: Token is not valid or X-Realm header is missing
+        '403':
+          description: User does not have specific role
   /scenarios/{scenario_id}:
     get:
       tags:

--- a/api/src/api/app/apis/simulations_api.py
+++ b/api/src/api/app/apis/simulations_api.py
@@ -47,7 +47,8 @@ async def create_simulations(
 
 # a toy endpoint to test authorization
 @router.post(
-    "/scenarios/protected")
+    "/scenarios/protected",
+    tags=["Simulations"])
 async def create_protected_scenario(user: User = Depends(verify_lha_user)) -> str:
     return """Scenario created by {}""".format(user)
 

--- a/api/src/api/app/apis/simulations_api.py
+++ b/api/src/api/app/apis/simulations_api.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from typing import List, Optional  # noqa: F401
+from typing import List, Optional
 
 from app.controller.simulation_controller import SimulationController
 from app.models.extra_models import TokenModel  # noqa: F401
@@ -17,19 +17,15 @@ from app.utils.constants import MigrationSort, MovementFilter
 from fastapi import (  # noqa: F401
     APIRouter,
     Body,
-    Cookie,
     Depends,
     File,
-    Form,
-    Header,
     Path,
     Query,
-    Response,
     Security,
     UploadFile,
-    status,
 )
-from security_api import get_token_bearerAuth
+from security_api import get_token_bearerAuth, verify_lha_user
+from services.auth import User
 
 router = APIRouter()
 simulation_controller = SimulationController()
@@ -49,6 +45,11 @@ async def create_simulations(
 ) -> ID:
     return simulation_controller.create_new_scenarios(new_scenario)
 
+# a toy endpoint to test authorization
+@router.post(
+    "/scenarios/protected")
+async def create_protected_scenario(user: User = Depends(verify_lha_user)) -> str:
+    return """Scenario created by {}""".format(user)
 
 @router.delete(
     "/scenarios/{scenario_id}",
@@ -64,7 +65,6 @@ async def delete_scenario(
 ) -> None:
     """deletes the Scenario and all its runs"""
     return simulation_controller.delete_scenario_by_id(scenario_id)
-
 
 @router.delete(
     "/scenarios/{scenario_id}/simulations/{runid}",

--- a/api/src/api/app/db/models.py
+++ b/api/src/api/app/db/models.py
@@ -3,6 +3,10 @@ from typing import List, Optional
 
 from sqlmodel import Field, Relationship, SQLModel, ARRAY, Float, Column
 
+# class AuditBase(SQLModel, table=False):
+#     created_by: Optional[str] = Field(default=None)
+#     created_at: Optional[datetime] = Field(default=None)
+
 class ModelGroupLink(SQLModel, table=True):
     group_id: Optional[str] = Field(
         default=None, foreign_key="group.id", primary_key=True, nullable=False
@@ -279,6 +283,8 @@ class Scenario(SQLModel, table=True):
         back_populates="scenarios", link_model=ScenarioParameterValueLink
     )
     runsimulations: List["RunSimulations"] = Relationship(back_populates="scenario")
+    owner: Optional[str] = Field(default=None)
+    
 
 
 class Migration(SQLModel, table=True):

--- a/api/src/api/app/db/models.py
+++ b/api/src/api/app/db/models.py
@@ -283,7 +283,6 @@ class Scenario(SQLModel, table=True):
         back_populates="scenarios", link_model=ScenarioParameterValueLink
     )
     runsimulations: List["RunSimulations"] = Relationship(back_populates="scenario")
-    owner: Optional[str] = Field(default=None)
     
 
 

--- a/api/src/api/security_api.py
+++ b/api/src/api/security_api.py
@@ -1,32 +1,84 @@
 # # coding: utf-8
 
-from typing import List, Union
-from fastapi import APIRouter
-from fastapi import Depends, Security  # noqa: F401
-from fastapi.openapi.models import OAuthFlowImplicit, OAuthFlows  # noqa: F401
+from fastapi import Header
+from fastapi import Depends  # noqa: F401
 from fastapi.security import (  # noqa: F401
     HTTPAuthorizationCredentials,
-    HTTPBasic,
-    HTTPBasicCredentials,
     HTTPBearer,
-    OAuth2,
-    OAuth2AuthorizationCodeBearer,
-    OAuth2PasswordBearer,
-    SecurityScopes,
 )
-from fastapi.security.api_key import APIKeyCookie, APIKeyHeader, APIKeyQuery  # noqa: F401
+from jwt import PyJWKClient
+import jwt  # noqa: F401
 
-from app.models.extra_models import TokenModel , User,UserInDB,Token,TokenData
-from datetime import datetime, timedelta
+from app.models.extra_models import TokenModel
 
-from fastapi import Depends, FastAPI, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
-# from jose import JWTError, jwt
-# router = APIRouter()
-from services.auth import VerifyToken
+from fastapi import Depends, HTTPException
+from fastapi.security.utils import get_authorization_scheme_param
+
+from services.auth import VerifyToken, User
 from core.config import REQUIRESAUTH
-bearer_auth = HTTPBearer()
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 
+async def realm_extractor(x_realm: str = Header("X-Realm")):
+    """Extract realm information from request header"""
+    if x_realm == "":
+        raise HTTPException(
+            status_code=HTTP_401_UNAUTHORIZED, 
+            detail="X-Realm header not specified"
+            )
+    return x_realm
+
+async def bearer_extractor(authorization: str = Header("Authorization")):
+    """Extract bearer token from request header"""
+    scheme, param = get_authorization_scheme_param(authorization)
+    if scheme.lower() != "bearer":
+        raise HTTPException(
+                status_code=HTTP_401_UNAUTHORIZED,
+                detail="Not authenticated",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+    return param
+
+async def verify_token(
+        access_token = Depends(bearer_extractor),
+        x_realm: str = Depends(realm_extractor)) -> User:
+    """Verify token and extract user information"""
+
+    url = f"https://lokiam.de/realms/{x_realm}/protocol/openid-connect/certs"
+    jwks_client = PyJWKClient(url)
+
+    try:
+        signing_key = jwks_client.get_signing_key_from_jwt(access_token)
+        payload = jwt.decode(
+            access_token,
+            signing_key.key,
+            algorithms=["RS256"],
+            audience="loki-back",
+            options={"verify_exp": True},
+        )
+
+        username = payload["sub"]
+        client = payload["azp"]
+        email = payload["email"]
+        try:
+            roles = payload["resource_access"][client]["roles"]
+        except KeyError:
+            roles = []
+
+        if username is None:
+            raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Username not specified")
+
+        return User(username, email, roles)
+    except jwt.exceptions.InvalidTokenError:
+        raise HTTPException(status_code=HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    
+def verify_lha_user(user: User = Depends(verify_token)):
+    """Verify that the user is a LHA user"""
+    if "lha-user" not in user.role:
+        raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail="User is not a LHA user")
+    return user
+
+# This is how they do authorization with OAuth2 in the past
+bearer_auth = HTTPBearer()
 async def get_token_bearerAuth(credentials: HTTPAuthorizationCredentials = Depends(bearer_auth)) -> TokenModel:
     """
     Check and retrieve authentication information from custom bearer token.
@@ -45,3 +97,4 @@ async def get_token_bearerAuth(credentials: HTTPAuthorizationCredentials = Depen
         # print(result)
         if result.get("status"):
             raise HTTPException(status_code=401, detail="Not authorized or invalid credentials")
+        

--- a/api/src/api/services/auth.py
+++ b/api/src/api/services/auth.py
@@ -1,6 +1,19 @@
 import jwt
 from core.config import DOMAIN, API_AUDIENCE, ALGORITHMS, ISSUER
 
+class User():
+    """A simple user model for authentication & authorization"""
+    def __init__(self, username: str, email: str = "", role: list[str] = []):
+        self.username = username
+        self.email = email
+        self.role = role
+
+    def __str__(self):
+        return """User(username="{}", email="{}", roles=[{}])""".format(
+            self.username, self.email, ", ".join(self.role)
+        )
+
+# deprecated: Used by get_token_bearerAuth which is a temporary setup
 class VerifyToken():
     """Does all the token verification using PyJWT"""
 

--- a/api/src/api/services/auth.py
+++ b/api/src/api/services/auth.py
@@ -14,6 +14,7 @@ class User():
         )
 
 # deprecated: Used by get_token_bearerAuth which is a temporary setup
+# now we use verify_token method in security_api.py
 class VerifyToken():
     """Does all the token verification using PyJWT"""
 


### PR DESCRIPTION
I didn't dare to touch any files so I defined classes methods in files that are already there. Most of my codes are under `api/src/api/security_api.py` which contains several request filter methods that extract and verify token from the request header and then cast it into a simple [`User`](https://github.com/SciCompMod/ESID-Backend/blob/cec29e6bc9a581b1439433ae4001a8842d32a6bf/api/src/api/services/auth.py#L4) object defined in `api/src/api/services/auth.py`. The toy endpoint is defined in `api/src/api/app/apis/simulations_api.py` as [`create_protected_scenario`](https://github.com/SciCompMod/ESID-Backend/blob/cec29e6bc9a581b1439433ae4001a8842d32a6bf/api/src/api/app/apis/simulations_api.py#L51).

To test it out, you need to switch to [my branch](https://github.com/DLR-SC/ESID/tree/feature/auth-backend-integration) for the ESID frontend. There I attached realm information (required in the backend for verifying the token) in the request header to the toy endpoint.

Cheers