### PR TITLE
Add create-by audit for scenario creation (again)

### DIFF
--- a/api/src/api/app/apis/scenarios_api.py
+++ b/api/src/api/app/apis/scenarios_api.py
@@ -45,10 +45,13 @@ async def create_scenario(
     scenario: Scenario = Body(None, description="")
 ) -> ID:
     """Create a new scenario to be simulated."""
+
+    # Tag creator info
+    scenario.creator_user_id = request.state.user.userId if request.state.user else None
+    scenario.creator_org_id = request.state.realm if request.state.realm else None
+    
     return await controller.create_scenario(
-        scenario,
-        request.state.user.userId if request.state.user else None,
-        request.state.realm if request.state.realm else None
+        scenario
     )
 
 

--- a/api/src/api/app/apis/scenarios_api.py
+++ b/api/src/api/app/apis/scenarios_api.py
@@ -41,10 +41,15 @@ logging.basicConfig(level=logging.INFO)
     response_model_by_alias=True,
 )
 async def create_scenario(
+    request: Request,
     scenario: Scenario = Body(None, description="")
 ) -> ID:
     """Create a new scenario to be simulated."""
-    return await controller.create_scenario(scenario)
+    return await controller.create_scenario(
+        scenario,
+        request.state.user.userId if request.state.user else None,
+        request.state.realm if request.state.realm else None
+    )
 
 
 @router.delete(

--- a/api/src/api/app/controller/scenario_controller.py
+++ b/api/src/api/app/controller/scenario_controller.py
@@ -61,14 +61,12 @@ class ScenarioController:
     
     async def create_scenario(
         self,
-        scenario: Optional[Scenario],
-        userId: Optional[str],
-        orgId: Optional[str]
+        scenario: Optional[Scenario]
     ) -> ID:
         """Create a new scenario to be simulated."""
         if not scenario:
             raise HTTPException(status_code=500, detail="No scenario provided")
-        return scenario_create(scenario, userId, orgId)
+        return scenario_create(scenario)
 
 
     async def delete_scenario(

--- a/api/src/api/app/controller/scenario_controller.py
+++ b/api/src/api/app/controller/scenario_controller.py
@@ -62,11 +62,13 @@ class ScenarioController:
     async def create_scenario(
         self,
         scenario: Optional[Scenario],
+        userId: Optional[str],
+        orgId: Optional[str]
     ) -> ID:
         """Create a new scenario to be simulated."""
         if not scenario:
             raise HTTPException(status_code=500, detail="No scenario provided")
-        return scenario_create(scenario)
+        return scenario_create(scenario, userId, orgId)
 
 
     async def delete_scenario(

--- a/api/src/api/app/db/models.py
+++ b/api/src/api/app/db/models.py
@@ -28,6 +28,8 @@ class Scenario(SQLModel, table=True):
     timestampSubmitted: Optional[datetime] = Field(default=None, nullable=True)
     timestampSimulated: Optional[datetime] = Field(default=None, nullable=True)
 
+    userId: Optional[str] = Field(default=None, nullable=True) # Created by user
+    orgId: Optional[str] = Field(default=None, nullable=True) # Created by user's LHA/Organization
 
 class ParameterDefinition(SQLModel, table=True):
     id: Optional[uuid.UUID] = Field(default_factory=uuid.uuid4, primary_key=True, nullable=False)

--- a/api/src/api/app/db/models.py
+++ b/api/src/api/app/db/models.py
@@ -28,8 +28,8 @@ class Scenario(SQLModel, table=True):
     timestampSubmitted: Optional[datetime] = Field(default=None, nullable=True)
     timestampSimulated: Optional[datetime] = Field(default=None, nullable=True)
 
-    userId: Optional[str] = Field(default=None, nullable=True) # Created by user
-    orgId: Optional[str] = Field(default=None, nullable=True) # Created by user's LHA/Organization
+    creatorUserId: Optional[uuid.UUID] = Field(default=None, nullable=True)
+    creatorOrgId: Optional[str] = Field(default=None, nullable=True)
 
 class ParameterDefinition(SQLModel, table=True):
     id: Optional[uuid.UUID] = Field(default_factory=uuid.uuid4, primary_key=True, nullable=False)

--- a/api/src/api/app/db/tasks.py
+++ b/api/src/api/app/db/tasks.py
@@ -412,7 +412,7 @@ def parameter_definition_delete(id: StrictStr) -> None:
 
 
 ## Scenarios ##
-def scenario_create(scenario: Scenario, userId: Optional[str], orgId: Optional[str]) -> ID:
+def scenario_create(scenario: Scenario) -> ID:
     scenario_obj = db.Scenario(
         name=scenario.name,
         description=scenario.description,
@@ -423,8 +423,8 @@ def scenario_create(scenario: Scenario, userId: Optional[str], orgId: Optional[s
         percentiles=','.join([str(perc) for perc in scenario.percentiles]) if scenario.percentiles else '50',
         timestampSubmitted=datetime.now(),
         timestampSimulated=None,
-        userId=userId,
-        orgId=orgId
+        creatorUserId=scenario.creator_user_id,
+        creatorOrgId=scenario.creator_org_id
     )
     with next(get_session()) as session:
         nested_dict = lambda: defaultdict(nested_dict)
@@ -538,6 +538,8 @@ def scenario_get_by_id(id: StrictStr) -> Scenario:
         percentiles=[int(perc) for perc in scenario.percentiles.split(',')] if scenario.percentiles else [50],
         timestampSubmitted=scenario.timestampSubmitted,
         timestampSimulated=scenario.timestampSimulated,
+        creator_user_id=str(scenario.creatorUserId),
+        creator_org_id=scenario.creatorOrgId
     )
 
 def scenario_get_all() -> List[ReducedScenario]:

--- a/api/src/api/app/db/tasks.py
+++ b/api/src/api/app/db/tasks.py
@@ -412,7 +412,7 @@ def parameter_definition_delete(id: StrictStr) -> None:
 
 
 ## Scenarios ##
-def scenario_create(scenario: Scenario) -> ID:
+def scenario_create(scenario: Scenario, userId: Optional[str], orgId: Optional[str]) -> ID:
     scenario_obj = db.Scenario(
         name=scenario.name,
         description=scenario.description,
@@ -423,6 +423,8 @@ def scenario_create(scenario: Scenario) -> ID:
         percentiles=','.join([str(perc) for perc in scenario.percentiles]) if scenario.percentiles else '50',
         timestampSubmitted=datetime.now(),
         timestampSimulated=None,
+        userId=userId,
+        orgId=orgId
     )
     with next(get_session()) as session:
         nested_dict = lambda: defaultdict(nested_dict)

--- a/api/src/api/app/middlewares/authentication_middleware.py
+++ b/api/src/api/app/middlewares/authentication_middleware.py
@@ -22,7 +22,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
                 # async def get_user(request: Request):
                 #     return request.state.user
                 request.state.user = user
-
+                request.state.realm = realm
                 # (Optional) role check can be added
                 # if ['admin'] not in user.role:
                 #     raise HTTPException(

--- a/api/src/api/app/models/scenario.py
+++ b/api/src/api/app/models/scenario.py
@@ -47,11 +47,9 @@ class Scenario(BaseModel):
     percentiles: Optional[List[StrictInt]] = Field(default=[50], description="List of available percentiles for this scenario", alias="percentiles")
     timestamp_submitted: Optional[datetime] = Field(default=None, alias="timestampSubmitted", description="Timestamp when the scenario was added/created")
     timestamp_simulated: Optional[datetime] = Field(default=None, alias="timestampSimulated", description="Timestamp when the scenario was finished simulating and data is available")
-    __properties: ClassVar[List[str]] = ["id", "name", "description", "startDate", "endDate", "modelId", "modelParameters", "nodeListId", "linkedInterventions", "percentiles", "timestampSubmitted", "timestampSimulated"]
-
-    creator_user_id: Optional[str] = None
-    creator_org_id: Optional[str] = None
-
+    creator_user_id: Optional[str] = Field(default=None, alias="creatorUserId", description="ID of the user who submitted the scenario")
+    creator_org_id: Optional[str] = Field(default=None, alias="creatorOrgId", description="ID of the organization the submitting user belongs to")
+    __properties: ClassVar[List[str]] = ["id", "name", "description", "startDate", "endDate", "modelId", "modelParameters", "nodeListId", "linkedInterventions", "percentiles", "timestampSubmitted", "timestampSimulated", "creatorUserId", "creatorOrgId"]
     model_config = {
         "populate_by_name": True,
         "validate_assignment": True,

--- a/api/src/api/app/models/scenario.py
+++ b/api/src/api/app/models/scenario.py
@@ -49,6 +49,9 @@ class Scenario(BaseModel):
     timestamp_simulated: Optional[datetime] = Field(default=None, alias="timestampSimulated", description="Timestamp when the scenario was finished simulating and data is available")
     __properties: ClassVar[List[str]] = ["id", "name", "description", "startDate", "endDate", "modelId", "modelParameters", "nodeListId", "linkedInterventions", "percentiles", "timestampSubmitted", "timestampSimulated"]
 
+    creator_user_id: Optional[str] = None
+    creator_org_id: Optional[str] = None
+
     model_config = {
         "populate_by_name": True,
         "validate_assignment": True,


### PR DESCRIPTION
Record user IDs and realm/LHA/Org IDs when creating new scenario. User IDs and Org IDs are extracted from the authentication middleware. I only changed the db model for Scenario but not any DTOs in between (I just changed the signature of those functions in controller and tasks). So far the User IDs are UUIDs generated by Keycloak, not username but we can change that upon request and the Org IDs are just the realm IDs on Keycloak as well. I think we might need to map those onto county code IDs?

Sorry for the weird commit and revert I made on main branch. I accidentally committed there. 