### PR TITLE
Change db volume mount path

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -37,9 +37,9 @@ services:
       - backnet
   db:
     restart: always
-    image: postgres:latest
+    image: postgres:18
     volumes:
-      - ${VOLUME_DIR}/postgres_data:/var/lib/postgresql/data/
+      - ${VOLUME_DIR}/postgres_data:/var/lib/postgresql
     env_file:
       - .docker-env
     networks:


### PR DESCRIPTION
When following the setup instruction, an error occur after the `docker compose up` step:
> ```Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/home/jackie/esid_volumes/postgres_data" to rootfs at "/var/lib/postgresql/data": change mount propagation through procfd: open o_path procfd: open /var/lib/docker/overlay2/470a780bbb3d6cd9e777588ff4d82b9338d72aa0b0f2410ecf57bd5bf0630a6a/merged/var/lib/postgresql/data: no such file or directory: unknown```

Because docker is pulling the latest PostgreSQL which is PostgreSQL 18 at the time and PGDATA path was changed after the release as described in [this issue](https://github.com/docker-library/postgres/issues/1364#issuecomment-3338937034).
I just fix PostgreSQL's version to 18 and update the PGDATA path in `docker-compose.yml`. Another possible fix would be downgrade PostgreSQL to <18.